### PR TITLE
Remove space in "gulpplugin" keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [
   	"git",
     "gulp",
-    "gulp plugin",
+    "gulpplugin",
     "gh-pages",
     "dist",
     "github"


### PR DESCRIPTION
Should be a single keyword.
Also it's better to match at the plugin-site! :)

https://github.com/gulpjs/plugins/blob/master/app/js/controller/pluginList.js#L9
