### PR TITLE
Remote git subtree notice, it just confuse people

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ First, install `gulp-gh-pages` as a development dependency
 npm install --save-dev gulp-gh-pages
 ```
 
-If your repository does not have a `gh-pages` branch, it is advised that you create one first. I used `git subtree push --prefix <dist folder> origin gh-pages`.
-
 Then define a `deploy` task in your `gulpfile.js` (as below) which can be used to push to `gh-pages` going forward.
 
 ```javascript


### PR DESCRIPTION
It seems this notice is just confusing people. That's not the first time I saw people telling me that they can't use subtree (like I did in the past - Ref #6).
It's totally not required now since a part of the script can create a branch if it doesn't exist.

Last time I got a similar comment was here https://github.com/gulpjs/gulp/pull/501#issuecomment-44803376
