### PR TITLE
Add gulp ^3.0.0 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "scripts": {
     "test": "jasmine-node test/"
   },
+  "peerDependencies": {
+    "gulp": "^3.0.0"
+  },
   "dependencies": {
     "through2": "^0.6.1",
     "gulp-util": "^3.0.1",


### PR DESCRIPTION
Could't use `gulp-gh-pages` in `npm link` mode during development without adding `gulp` as a peer dependency.

Using `peerDependencies` as `gulp-gh-pages` is a plugin to `gulp`. Using version `^3.0.0` as `npm test` passed for `3.0.0` as well as the latest `3.8.10` version. Leanient peer dependency versioning is encouraged.
http://blog.nodejs.org/2013/02/07/peer-dependencies/

Note: `gulp` could also be a dev dependency, if test are written for `index.js`. I don't think Travis uses `peerDependencies` though.