### PR TITLE
Add 'force' option, to 'git add --force' files which are ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ Default: `true`
 
 Allow you to make a build on the defined branch without pushing it to master. Useful for dry run.
 
+#### options.force
+
+Type: `Boolean`
+Default: `false`
+
+Force adding files to the `gh-pages` branch, even if they are ignored by `.gitignore` or `.gitignore_global`.
+
 #### options.message
 
 Type: `String`

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports = function (options) {
 	var branch = options.branch || 'gh-pages';
 	var cacheDir = options.cacheDir;
 	var push = options.push === undefined ? true : options.push;
+	var force = options.force === undefined ? false : options.force;
 	var message = options.message || 'Update ' + new Date().toISOString();
 
 	var filePaths = [];
@@ -118,7 +119,10 @@ module.exports = function (options) {
 			return deferred.promise;
 		})
 		.then(function (repo) {
-			return repo.addFiles('.');
+			var addOptions = options.force ? {
+				force: options.force
+			} : undefined;
+			return repo.addFiles('.', addOptions);
 		})
 		.then(function (repo) {
 			var filesToBeCommitted = Object.keys(repo._staged).length;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "lodash": "^2.4.1"
   },
   "devDependencies": {
-    "jasmine-node": "~1.14.3"
+    "jasmine-node": "~1.14.3",
+    "mkdirp": "^0.5.0"
   },
   "engines": {
     "node": ">=0.10.0",

--- a/test/fixtures/.gitignore
+++ b/test/fixtures/.gitignore
@@ -1,0 +1,2 @@
+ignored-file.txt
+ignored-folder/

--- a/test/fixtures/ignored-file.txt
+++ b/test/fixtures/ignored-file.txt
@@ -1,0 +1,1 @@
+This file is ignored by default.

--- a/test/fixtures/ignored-folder/file-in-ignored-folder.txt
+++ b/test/fixtures/ignored-folder/file-in-ignored-folder.txt
@@ -1,0 +1,1 @@
+This entire folder is ignored by default.


### PR DESCRIPTION
This is because the `gh-pages` branch may contain files which are oftentimes ignored in `.gitignore_global`, such as generated files or parts of other packages (`npm`, `bower`, etc).