### PR TITLE
Always push to "origin".

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ module.exports = function (options) {
 				.then(function (repo) {
 					if (push) {
 						gutil.log(TAG + 'Pushing to remote.');
-						return repo.push(origin);
+						return repo.push();
 					}
 				});
 			}


### PR DESCRIPTION
When cloning the remote becomes "origin" in the cloned repository. So when we push, we have to push to "origin". This fixes the problem with cross-repository deployment.

This scenario assumes that `remoteUrl` is not used, but instead, using git remote, such as:

```
git remote add www https://...@github.com/username/username.github.io.git
```

and piping using:

```javascript
    .pipe(deploy({
      origin: 'www',
      branch: 'master',
    }))
```