### PR TITLE
fixed cli warning: npm WARN deprecation setting `ngine-strict` instead.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,10 @@
     "read-remove-file": "^1.0.1",
     "vinyl": "^0.4.6"
   },
+  "engine-strict": {
+    "node": ">=0.10.0",
+    "npm": ">=2.6.0"
+  },
   "jscsConfig": {
     "preset": "google",
     "maximumLineLength": 98,


### PR DESCRIPTION
```
npm WARN deprecation Per-package engineStrict will no longer be used
npm WARN deprecation in upcoming versions of npm. Use the config
npm WARN deprecation setting `engine-strict` instead.
gulp-gh-pages@0.5.0 node_modules/gulp-gh-pages
├── gift@0.5.0
├── wrap-promise@1.0.0 (es6-promise@2.0.1)
├── through2@0.6.5 (xtend@4.0.0, readable-stream@1.0.33)
├── rimraf@2.3.2 (glob@4.5.3)
├── vinyl-fs@1.0.0 (object-assign@2.0.0, merge-stream@0.1.7, graceful-fs@3.0.6, mkdirp@0.5.0, vinyl@0.4.6, strip-bom@1.0.0, duplexify@3.2.0, glob-watcher@0.0.8, glob-stream@4.1.1)
└── gulp-util@3.0.4 (array-differ@1.0.0, beeper@1.0.0, array-uniq@1.0.2, object-assign@2.0.0, lodash._reinterpolate@3.0.0, lodash._reevaluate@3.0.0, lodash._reescape@3.0.0, replace-ext@0.0.1, minimist@1.1.1, vinyl@0.4.6, multipipe@0.1.2, chalk@1.0.0, lodash.template@3.4.0, dateformat@1.0.11)
```

already fixed it