### PR TITLE
Allow you to override old files instead of removing and copying.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ Default: `"Update [timestamp]"`
 
 Edit commit message.
 
+#### options.remove
+
+Type: `Boolean`  
+Default: `true`
+
+Allow you to override old files instead of removing and copying.
+`true` for remove and copy. `false` for override.
+Useful when you want to keep old builds.
+
 ## License
 
 Copyright (c) 2014 [Micheal Benedict](https://github.com/rowoot), 2015 [Shinnosuke Watanabe](https://github.com/shinnn)

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var wrapPromise = require('wrap-promise');
  *   - cacheDir: {String} where the git repo will be located. (default to a temporary folder)
  *   - push: {Boolean} to know whether or not the branch should be pushed (default to `true`)
  *   - message: {String} commit message (default to `"Update [timestamp]"`)
+ *   - remove: {Boolean} to know whether or not the old files should be removed (default to `true`)
  *
  * Returns `Stream`.
 **/
@@ -96,13 +97,17 @@ module.exports = function gulpGhPages(options) {
       .then(function(repo) {
         // remove all files
         return wrapPromise(function(resolve, reject) {
-          repo._repo.remove('.', {r: true}, function(err) {
-            if (err) {
-              reject(err);
-              return;
-            }
+          if (options.remove === undefined || options.remove) {
+            repo._repo.remove('.', {r: true}, function(err) {
+              if (err) {
+                reject(err);
+                return;
+              }
+              resolve(repo.status());
+            });
+          } else {
             resolve(repo.status());
-          });
+          }
         });
       })
       .then(function(repo) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-gh-pages",
-  "version": "0.5.5",
+  "version": "0.5.4",
   "description": "gulp plugin to publish contents to Github pages",
   "repository": "shinnn/gulp-gh-pages",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-gh-pages",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "gulp plugin to publish contents to Github pages",
   "repository": "shinnn/gulp-gh-pages",
   "license": "MIT",


### PR DESCRIPTION
hey, i just added this option:
#### options.remove

Type: `Boolean`  
Default: `true`

Allow you to override old files instead of removing and copying.
`true` for remove and copy. `false` for override.
Useful when you want to keep old builds.
