### PR TITLE
Suggest using gulp-file to set CNAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ Now, you should be able to call your task by doing:
 gulp deploy
 ```
 
+## CNAME
+
+If you are using a [custom domain name](https://help.github.com/articles/using-a-custom-domain-with-github-pages/) with your GitHub Pages site, you need to add a CNAME file. You could create this file as part of your deploy task using something like [gulp-file](https://www.npmjs.com/package/gulp-file):
+
+```javascript
+var gulp = require('gulp');
+var ghPages = require('gulp-gh-pages');
+var file = require('gulp-file');
+
+gulp.task('deploy', function() {
+  return gulp.src('./dist/**/*')
+    .pipe(file('CNAME', 'www.example.com'))
+    .pipe(ghPages());
+});
+```
+
 ## API
 
 ```javascript


### PR DESCRIPTION
It was decided that instead of including an `options.cname` property, users should use small single-purpose gulp plugins (#27) 

While not 100% necessary, it seems curious to suggest this strategy to users in the README, hence this PR.

IMO explaining best practices is always a good idea.